### PR TITLE
added variable to turn tomcat version from showing on and off

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ tomcat_ajp_port: 8009
 tomcat_jre_home: /usr
 tomcat_max_threads: 600
 tomcat_server_name: tomcat
+tomcat_error_report_valve: yes
 tomcat_remote_ip_valve: yes
 tomcat_sysconfig_path: /etc/sysconfig
 tomcat_logs_path: /var/log

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -166,6 +166,10 @@
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 
+{% if tomcat_error_report_valve %}
+        <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
+{% endif %}
+
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--


### PR DESCRIPTION
---
name: Pull request
about: Remove version from showing on error pages within Apache Tomcat.

---

**Describe the change**
Added default variable that allows the turning on and off of the version showing on error pages.

**Testing**
Tested adding the parameter to server.xml in docker and no longer seeing version in error pages.
